### PR TITLE
feat: add Output option

### DIFF
--- a/nodes/DependencyAnalytics/DependencyAnalytics.spec.ts
+++ b/nodes/DependencyAnalytics/DependencyAnalytics.spec.ts
@@ -13,21 +13,23 @@ test('It contains the icon', () => {
 test('It contains all expected displayNames in properties', () => {
 	const node = new DependencyAnalytics();
 	const displayNames = node.description.properties.map((prop: any) => prop.displayName);
-
 	const expectedDisplayNames = [
 		'Authentication Method',
 		'Base URL',
 		'Resource',
 		'Identifier',
 		'Limit',
-		'Simplify',
+		'Output',
+		'Selected Fields',
 		'Operation',
 		'Sorting',
+		'Selected Fields',
 		'Operation',
 		'Input Type',
 		'PURLs',
 		'SBOM SHA-256',
 		'Sorting',
+		'Selected Fields',
 		'Operation',
 	];
 

--- a/nodes/DependencyAnalytics/actions/vulnerability.ts
+++ b/nodes/DependencyAnalytics/actions/vulnerability.ts
@@ -1,10 +1,10 @@
 import type { IExecuteFunctions, INodeExecutionData, IHttpRequestOptions } from 'n8n-workflow';
 import { authedRequest, chooseCredential, defaultJsonHeaders, getBase } from '../utils/http';
-import { simplifyOne } from '../utils/simplify';
 import { parsePurls } from '../utils/parsePurls';
 import { throwError } from '../utils/errors';
 import { multiCmp, SortRule } from '../utils/sort';
 import { readSortRules } from '../utils/readSort';
+import { shapeOutput } from '../utils/output';
 
 export async function get({ ctx, itemIndex }: { ctx: IExecuteFunctions; itemIndex: number }) {
 	const credentialName = chooseCredential(ctx, itemIndex);
@@ -20,8 +20,8 @@ export async function get({ ctx, itemIndex }: { ctx: IExecuteFunctions; itemInde
 	};
 
 	const res = await authedRequest(ctx, credentialName, options);
-	const simplify = ctx.getNodeParameter('simplify', itemIndex, true) as boolean;
-	return simplify ? { ...simplifyOne('vulnerability', res) } : res;
+	return shapeOutput(ctx, itemIndex, 'vulnerability', res);
+
 }
 
 export async function getMany({ ctx, itemIndex }: { ctx: IExecuteFunctions; itemIndex: number }) {
@@ -40,16 +40,14 @@ export async function getMany({ ctx, itemIndex }: { ctx: IExecuteFunctions; item
 	const res = (await authedRequest(ctx, credentialName, options)) as any;
 	const items: any[] = Array.isArray(res?.items) ? res.items : [];
 	const rules: SortRule[] = readSortRules(ctx, itemIndex, 'vulnerability');
-	const simplify = ctx.getNodeParameter('simplify', itemIndex, true) as boolean;
 
 	let out = items;
 	if (rules.length) out = [...out].sort((a, b) => multiCmp(a, b, rules, 'vulnerability'));
 
 	out = out.slice(0, limit);
 
-	const finalItems = simplify ? out.map((it) => simplifyOne('vulnerability', it)) : out;
-
-	return [{ json: { ...res, items: finalItems } } as INodeExecutionData];
+	const finalItems = out.map((it) => shapeOutput(ctx, itemIndex, 'vulnerability', it));
+  return [{ json: { ...res, items: finalItems } }];
 }
 
 export async function analyze({ ctx, itemIndex }: { ctx: IExecuteFunctions; itemIndex: number }) {

--- a/nodes/DependencyAnalytics/descriptions/advisory.properties.ts
+++ b/nodes/DependencyAnalytics/descriptions/advisory.properties.ts
@@ -2,6 +2,28 @@ import type { INodeProperties } from 'n8n-workflow';
 
 export const advisoryProperties: INodeProperties[] = [
 	{
+		displayName: 'Selected Fields',
+		name: 'advisorySelectedFields',
+		type: 'multiOptions',
+		default: [],
+		options: [
+			{ name: 'Average Score', value: 'average_score' },
+			{ name: 'Average Severity', value: 'average_severity' },
+			{ name: 'Document ID', value: 'document_id' },
+			{ name: 'Identifier', value: 'identifier' },
+			{ name: 'Ingested', value: 'ingested' },
+			{ name: 'Issuer Name', value: 'issuer.name' },
+			{ name: 'Modified', value: 'modified' },
+			{ name: 'Published', value: 'published' },
+			{ name: 'Size (Bytes)', value: 'size' },
+			{ name: 'Title', value: 'title' },
+		],
+		displayOptions: {
+			show: { operation: ['get', 'getMany'], resource: ['advisory'], outputMode: ['selected'] },
+		},
+	},
+
+	{
 		displayName: 'Operation',
 		name: 'operation',
 		type: 'options',

--- a/nodes/DependencyAnalytics/descriptions/common.properties.ts
+++ b/nodes/DependencyAnalytics/descriptions/common.properties.ts
@@ -57,13 +57,22 @@ export const commonProperties: INodeProperties[] = [
 		description: 'Max number of results to return',
 	},
 	{
-		displayName: 'Simplify',
-		name: 'simplify',
-		type: 'boolean',
-		default: true,
-		description: 'Whether to return a simplified version of the response instead of the raw data',
-		displayOptions: {
-			show: { resource: ['sbom', 'vulnerability', 'advisory'], operation: ['get', 'getMany'] },
-		},
-	},
+    displayName: 'Output',
+    name: 'outputMode',
+    type: 'options',
+    default: 'simplified',
+    description:
+      'How to shape the response. In AI tool mode, keep it small to avoid context issues.',
+    options: [
+      { name: 'Simplified', value: 'simplified' },
+      { name: 'Raw', value: 'raw' },
+      { name: 'Selected Fields', value: 'selected' },
+    ],
+    displayOptions: {
+      show: {
+        operation: ['get', 'getMany'],
+        resource: ['sbom', 'vulnerability', 'advisory'],
+      },
+    },
+  },
 ];

--- a/nodes/DependencyAnalytics/descriptions/sbom.properties.ts
+++ b/nodes/DependencyAnalytics/descriptions/sbom.properties.ts
@@ -2,6 +2,27 @@ import type { INodeProperties } from 'n8n-workflow';
 
 export const sbomProperties: INodeProperties[] = [
 	{
+		displayName: 'Selected Fields',
+		name: 'sbomSelectedFields',
+		type: 'multiOptions',
+		default: [],
+		options: [
+			{ name: 'Document ID', value: 'document_id' },
+			{ name: 'ID', value: 'id' },
+			{ name: 'Ingested', value: 'ingested' },
+			{ name: 'Name', value: 'name' },
+			{ name: 'Packages (Count)', value: 'number_of_packages' },
+			{ name: 'Published', value: 'published' },
+			{ name: 'PURL', value: 'purl' },
+			{ name: 'SHA-256', value: 'sha256' },
+			{ name: 'Size (Bytes)', value: 'size' },
+			{ name: 'Version', value: 'version' },
+		],
+		description: 'Fields to include when using “Selected fields”. ID is always included.',
+		displayOptions: { show: { operation: ['get', 'getMany'], resource: ['sbom'], outputMode: ['selected'] } },
+	},
+
+	{
 		displayName: 'Operation',
 		name: 'operation',
 		type: 'options',
@@ -52,4 +73,6 @@ export const sbomProperties: INodeProperties[] = [
 			},
 		],
 	},
+
+
 ];

--- a/nodes/DependencyAnalytics/descriptions/vulnerability.properties.ts
+++ b/nodes/DependencyAnalytics/descriptions/vulnerability.properties.ts
@@ -2,6 +2,31 @@ import type { INodeProperties } from 'n8n-workflow';
 
 export const vulnerabilityProperties: INodeProperties[] = [
 	{
+		displayName: 'Selected Fields',
+		name: 'vulnSelectedFields',
+		type: 'multiOptions',
+		default: [],
+		options: [
+			{ name: 'Advisories', value: 'advisories' },
+			{ name: 'Average Score', value: 'average_score' },
+			{ name: 'Average Severity', value: 'average_severity' },
+			{ name: 'CWEs', value: 'cwes' },
+			{ name: 'Identifier', value: 'identifier' },
+			{ name: 'Modified', value: 'modified' },
+			{ name: 'Published', value: 'published' },
+			{ name: 'Reserved', value: 'reserved' },
+			{ name: 'Title', value: 'title' },
+			{ name: 'Withdrawn', value: 'withdrawn' },
+		],
+		displayOptions: {
+			show: {
+				operation: ['get', 'getMany'],
+				resource: ['vulnerability'],
+				outputMode: ['selected'],
+			},
+		},
+	},
+	{
 		displayName: 'Operation',
 		name: 'operation',
 		type: 'options',

--- a/nodes/DependencyAnalytics/utils/output.ts
+++ b/nodes/DependencyAnalytics/utils/output.ts
@@ -1,0 +1,69 @@
+import type { IExecuteFunctions } from 'n8n-workflow';
+import { simplifyOne } from './simplify';
+
+type Resource = 'sbom' | 'vulnerability' | 'advisory';
+
+function ensureId(resource: Resource, fields: string[]): string[] {
+	const must =
+		resource === 'sbom' ? 'id' :
+		resource === 'vulnerability' ? 'identifier' :
+		'document_id';
+	return fields.includes(must) ? fields : [must, ...fields];
+}
+
+// dot-path get for nested fields (issuer.name)
+function getPath(obj: any, path: string) {
+	if (!path.includes('.')) return obj?.[path];
+	return path.split('.').reduce((acc, k) => (acc == null ? acc : acc[k]), obj);
+}
+
+function project(obj: any, fields: string[]) {
+	const out: Record<string, any> = {};
+	for (const f of fields) out[f] = getPath(obj, f);
+	return out;
+}
+
+// Derive convenient top-level fields for SBOM when using Selected Fields mode.
+function first<T = any>(v: any): T | undefined {
+    return Array.isArray(v) ? v[0] : undefined;
+}
+
+function deriveSbomFields(source: any): any {
+    const described = first(source?.described_by) ?? {};
+    const firstPurl = first(described?.purl)?.purl;
+    const derived = {
+        name: source?.name ?? described?.name ?? null,
+        version: described?.version ?? null,
+        purl: firstPurl ?? null,
+    };
+    return { ...source, ...derived };
+}
+
+export function readSelectedFields(ctx: IExecuteFunctions, i: number, resource: Resource): string[] {
+	const name =
+		resource === 'sbom' ? 'sbomSelectedFields' :
+		resource === 'vulnerability' ? 'vulnSelectedFields' :
+		'advisorySelectedFields';
+	const v = ctx.getNodeParameter(name, i, []) as string[];
+	return Array.isArray(v) ? v : [];
+}
+
+export function shapeOutput(
+	ctx: IExecuteFunctions,
+	i: number,
+	resource: Resource,
+	obj: any,
+): any {
+	const mode = (ctx.getNodeParameter('outputMode', i, 'simplified') as 'simplified' | 'raw' | 'selected');
+
+	if (mode === 'raw') return obj;
+
+	if (mode === 'simplified') {
+		return simplifyOne(resource, obj);
+	}
+
+	// selected fields
+	const selected = ensureId(resource, readSelectedFields(ctx, i, resource));
+	const source = resource === 'sbom' ? deriveSbomFields(obj) : obj;
+	return project(source, selected);
+}


### PR DESCRIPTION
AI tool nodes: ‘Output’ parameter[#](https://docs.n8n.io/integrations/creating-nodes/build/reference/ux-guidelines/#ai-tool-nodes-output-parameter)
When an endpoint returns data with more than 10 fields, add the 'Output' option parameter with 3 modes.

In AI tool nodes, allow the user to be more granular and select the fields to output. The rationale is that tools may run out of context window and they can get confused by too many fields, so it's better to pass only the ones they need.

Options:

Simplified: Works the same as the "Simplify" parameter described above.
Raw: Returns all the available fields.
Selected fields: Shows a multi-option parameter for selecting the fields to add to the output and send to the AI agent. By default, this option always returns the ID of the record/entity.